### PR TITLE
adding electron and photon MVA V2 IDs

### DIFF
--- a/DataFormats/interface/TElectron.hh
+++ b/DataFormats/interface/TElectron.hh
@@ -25,6 +25,7 @@ namespace baconhep
       mva(-999.),
       mvaIso(-999.),
       mvaV2Iso(-999.), mvaV2NoIso(-999.),
+      mvaHZZ(-999.),
       regscale(0.),regsmear(0.),
       q(0),
       isConv(false), nMissingHits(0),
@@ -55,6 +56,8 @@ namespace baconhep
       float          mvaIsoCat;                                // electron ID Iso MVA category
       float          mvaV2Iso, mvaV2NoIso;                     // electron V2 MVA IDs
       float          mvaV2IsoCat, mvaV2NoIsoCat;               // electron V2 MVA ID category
+      float          mvaHZZ;                                   // electron HZZ MVA ID
+      float          mvaHZZCat;                                // electron HZZ MVA ID category
       float          regscale,regsmear;                        //Regression scale and smear corrections
       int            q;                                        // charge
       bool           isConv;                                   // identified by track fit based conversion finder?

--- a/DataFormats/interface/TElectron.hh
+++ b/DataFormats/interface/TElectron.hh
@@ -24,6 +24,7 @@ namespace baconhep
       dEtaInSeed(0), dEtaIn(0), dPhiIn(0),
       mva(-999.),
       mvaIso(-999.),
+      mvaV2Iso(-999.), mvaV2NoIso(-999.),
       regscale(0.),regsmear(0.),
       q(0),
       isConv(false), nMissingHits(0),
@@ -52,6 +53,8 @@ namespace baconhep
       float          mvaCat;                                   // electron ID MVA category
       float          mvaIso;                                   // electron ID Iso MVA value
       float          mvaIsoCat;                                // electron ID Iso MVA category
+      float          mvaV2Iso, mvaV2NoIso;                     // electron V2 MVA IDs
+      float          mvaV2IsoCat, mvaV2NoIsoCat;               // electron V2 MVA ID category
       float          regscale,regsmear;                        //Regression scale and smear corrections
       int            q;                                        // charge
       bool           isConv;                                   // identified by track fit based conversion finder?
@@ -65,7 +68,7 @@ namespace baconhep
       int            trkID;                                    // track ID number (unique per event)
       TriggerObjects hltMatchBits;                             // HLT matches
       
-    ClassDef(TElectron,5)
+    ClassDef(TElectron,6)
   };
 
   enum EEleType

--- a/DataFormats/interface/TPhoton.hh
+++ b/DataFormats/interface/TPhoton.hh
@@ -16,7 +16,7 @@ namespace baconhep
       trkIso(-1), ecalIso(-1), hcalIso(-1),
       chHadIso(-1), gammaIso(-1), neuHadIso(-1),
 //      chHadIsoSelVtx, chHadIso03WstVtx;
-      mva(0),
+      mva(-999.), mvaV2(-999.), 
       hovere(0), sthovere(0), sieie(0), sipip(0), r9(0), r9_full5x5(0),
       fiducialBits(0),
       typeBits(0),
@@ -33,6 +33,8 @@ namespace baconhep
       float          chHadIso, gammaIso, neuHadIso;        // PF isolation variables
 //      float          chHadIsoSelVtx,chHadIso03WstVtx;      // Isolation from the PV vs worst vertex Iso
       float          mva;                                  // Photon MVA ID
+      float          mvaV2;                                // Photon MVA V2 ID
+      float          mvaCat, mvaV2Cat;                     // Photon MVA categories
       float          hovere;                               // H/E
       float          sthovere;                             // Single tower H/E (https://twiki.cern.ch/twiki/bin/viewauth/CMS/HoverE2012)
       float          sieie, sipip, r9, r9_full5x5;         // shower shape


### PR DESCRIPTION
This adds the Fall17V2 electron and photon MVA IDs to Bacon. These are expected to perform better than v1 in general, and it's recommended to use them for 2016 for consistency. So I am proposing they are saved for all years. The old MVA values are still stored for 2016, so Bacon users can choose to stick with the old IDs if they so choose.

The HZZ MVA electron ID is also added for 2016 with a configuration flag to toggle on/off. 