### PR TITLE
Egamma updates and triggers

### DIFF
--- a/DataFormats/data/HLTFile_25ns
+++ b/DataFormats/data/HLTFile_25ns
@@ -76,6 +76,8 @@ HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*                                  hltL3f
 HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*                                  hltDiMuonGlb17Trk8RelTrkIsoFiltered0p4                                            2
 HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*                            hltL3fL1DoubleMu155fFiltered17                                                    1 
 HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*                            hltDiMuon178RelTrkIsoFiltered0p4                                                  2 
+HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*                              hltL3fL1DoubleMu155fFiltered17                                                    1 
+HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*                              hltDiMuon178RelTrkIsoFiltered0p4                                                  2 
 HLT_Mu7p5_Track2_Jpsi_v*                                                  hltMu7p5Track2JpsiTrackMassFiltered                                               1
 HLT_Mu7p5_Track7_Jpsi_v*                                                  hltMu7p5Track7JpsiTrackMassFiltered                                               1
 HLT_Mu7p5_Track2_Upsilon_v*                                               hltMu7p5Track2UpsilonTrackMassFiltered                                            1

--- a/DataFormats/data/HLTFile_25ns
+++ b/DataFormats/data/HLTFile_25ns
@@ -74,6 +74,12 @@ HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*                                     hltL3f
 HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*                                     hltDiMuonGlb17Trk8RelTrkIsoFiltered0p4                                            2
 HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*                                  hltL3fL1sDoubleMu114L1f0L2f10L3Filtered17                                         1
 HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*                                  hltDiMuonGlb17Trk8RelTrkIsoFiltered0p4                                            2
+HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*                            hltL3fL1DoubleMu155fFiltered17                                                    1 
+HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*                            hltDiMuon178RelTrkIsoFiltered0p4                                                  2 
+HLT_Mu7p5_Track2_Jpsi_v*                                                  hltMu7p5Track2JpsiTrackMassFiltered                                               1
+HLT_Mu7p5_Track7_Jpsi_v*                                                  hltMu7p5Track7JpsiTrackMassFiltered                                               1
+HLT_Mu7p5_Track2_Upsilon_v*                                               hltMu7p5Track2UpsilonTrackMassFiltered                                            1
+HLT_Mu7p5_Track7_Upsilon_v*                                               hltMu7p5Track7UpsilonTrackMassFiltered                                            1
 HLT_DoubleIsoMu17_eta2p1_v*                                               hltL3crIsoL1sDoubleMu125L1f16erL2f10QL3f17QL3Dz0p2L3crIsoRhoFiltered0p15IterTrk02 1
 HLT_DoubleIsoMu17_eta2p1_noDzCut_v*                                       hltL3crIsoL1sDoubleMu125L1f16erL2f10QL3f17QL3L3crIsoRhoFiltered0p15IterTrk02      1
 HLT_Mu8_TrkIsoVVL_v*                                                      hltL3fL1sMu5L1f0L2f5L3Filtered8TkIsoFiltered0p4                                   1
@@ -98,6 +104,9 @@ HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*                                 hltEle
 HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*                                 hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter                               2
 HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*                              hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter                               1
 HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*                              hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter                               2
+HLT_DoubleMu20_7_Mass0to30_Photon23_v*                                    hltEG23HEFilter                                                                   1
+HLT_Mu17_Photon30_IsoCaloId_v*                                            hltMu17Photon30IsoCaloIdMuonlegL3Filtered17Q                                      1
+HLT_Mu17_Photon30_IsoCaloId_v*                                            hltMu17Photon30IsoCaloIdPhotonlegTrackIsoFilter                                   2
 HLT_DoubleEle24_22_eta2p1_WPLoose_Gsf_v*                                  hltEle24Ele22WPLooseGsfleg1TrackIsoFilter                                         1
 HLT_DoubleEle24_22_eta2p1_WPLoose_Gsf_v*                                  hltEle24Ele22WPLooseGsfleg2TrackIsoFilter                                         2
 HLT_Ele8_CaloIdL_TrackIdL_IsoVL_PFJet30_v*                                hltEle8CaloIdLTrackIdLIsoVLTrackIsoFilter                                         1

--- a/DataFormats/interface/TElectron.hh
+++ b/DataFormats/interface/TElectron.hh
@@ -10,7 +10,13 @@ namespace baconhep
   {
     public:
       TElectron():
-      pt(0), eta(0), phi(0), calibPt(0), calibE(0),
+      pt(0), eta(0), phi(0), calibPt(0), calibE(0), calibEcalE(0),
+      calibPtErr(0),
+      energyScaleStatUp(0), energyScaleStatDown(0), 
+      energyScaleSystUp(0), energyScaleSystDown(0),
+      energyScaleGainUp(0), energyScaleGainDown(0),
+      energySigmaRhoUp(0), energySigmaRhoDown(0),
+      energySigmaPhiUp(0), energySigmaPhiDown(0),
       scEt(0), scEta(0), scPhi(0), ecalEnergy(0),
       pfPt(0), pfEta(0), pfPhi(0),
       trkIso(-1), ecalIso(-1), hcalIso(-1), hcalDepth1Iso(-1),
@@ -22,10 +28,12 @@ namespace baconhep
       sieie(0), e1x5(0), e2x5(0), e5x5(0), r9(0),
       eoverp(0), hovere(0), fbrem(0),
       dEtaInSeed(0), dEtaIn(0), dPhiIn(0),
-      mva(-999.),
-      mvaIso(-999.),
-      mvaV2Iso(-999.), mvaV2NoIso(-999.),
-      mvaHZZ(-999.),
+      //mva(-999.),
+      //mvaIso(-999.),
+      //mvaV2Iso(-999.), mvaV2NoIso(-999.),
+      //mvaHZZ(-999.),
+      mvaSpring16(-999.), mvaFall17V1Iso(-999.), mvaFall17V1NoIso(-999.),
+      mvaFall17V2Iso(-999.), mvaFall17V2NoIso(-999.), mvaSpring16HZZ(-999.),
       regscale(0.),regsmear(0.),
       q(0),
       isConv(false), nMissingHits(0),
@@ -35,7 +43,13 @@ namespace baconhep
       {}
       ~TElectron(){}
     
-      float          pt, eta, phi, calibPt, calibE;            // kinematics
+      float          pt, eta, phi, calibPt, calibE, calibEcalE;// kinematics
+      float          calibPtErr;                               // error on pt post scale/smearing
+      float          energyScaleStatUp, energyScaleStatDown;   // uncertainties on kinematics with scale/smearing
+      float          energyScaleSystUp, energyScaleSystDown;
+      float          energyScaleGainUp, energyScaleGainDown;
+      float          energySigmaRhoUp, energySigmaRhoDown;
+      float          energySigmaPhiUp, energySigmaPhiDown;
       float          scEt, scEta, scPhi;                       // supercluster kinematics
       float          ecalEnergy;                               // ECAL energy
       float          pfPt, pfEta, pfPhi;                       // matching PF-candidate kinematics
@@ -50,14 +64,26 @@ namespace baconhep
       float          hovere;                                   // H/E
       float          fbrem;                                    // brem fraction
       float          dEtaInSeed, dEtaIn, dPhiIn;               // track-supercluster matching
-      float          mva;                                      // electron ID MVA value
-      float          mvaCat;                                   // electron ID MVA category
-      float          mvaIso;                                   // electron ID Iso MVA value
-      float          mvaIsoCat;                                // electron ID Iso MVA category
-      float          mvaV2Iso, mvaV2NoIso;                     // electron V2 MVA IDs
-      float          mvaV2IsoCat, mvaV2NoIsoCat;               // electron V2 MVA ID category
-      float          mvaHZZ;                                   // electron HZZ MVA ID
-      float          mvaHZZCat;                                // electron HZZ MVA ID category
+      //float          mva;                                      // electron ID MVA value
+      //float          mvaCat;                                   // electron ID MVA category
+      //float          mvaIso;                                   // electron ID Iso MVA value
+      //float          mvaIsoCat;                                // electron ID Iso MVA category
+      //float          mvaV2Iso, mvaV2NoIso;                     // electron V2 MVA IDs
+      //float          mvaV2IsoCat, mvaV2NoIsoCat;               // electron V2 MVA ID category
+      //float          mvaHZZ;                                   // electron HZZ MVA ID
+      //float          mvaHZZCat;                                // electron HZZ MVA ID category
+      float          mvaSpring16;
+      float          mvaFall17V1Iso;
+      float          mvaFall17V1NoIso;
+      float          mvaFall17V2Iso;
+      float          mvaFall17V2NoIso;
+      float          mvaSpring16HZZ;
+      float          mvaSpring16Cat;
+      float          mvaFall17V1IsoCat;
+      float          mvaFall17V1NoIsoCat;
+      float          mvaFall17V2IsoCat;
+      float          mvaFall17V2NoIsoCat;
+      float          mvaSpring16HZZCat;
       float          regscale,regsmear;                        //Regression scale and smear corrections
       int            q;                                        // charge
       bool           isConv;                                   // identified by track fit based conversion finder?
@@ -71,7 +97,7 @@ namespace baconhep
       int            trkID;                                    // track ID number (unique per event)
       TriggerObjects hltMatchBits;                             // HLT matches
       
-    ClassDef(TElectron,6)
+    ClassDef(TElectron,7)
   };
 
   enum EEleType

--- a/DataFormats/interface/TPhoton.hh
+++ b/DataFormats/interface/TPhoton.hh
@@ -12,11 +12,17 @@ namespace baconhep
       TPhoton():
       pt(0), eta(0), phi(0),
       scEt(0), scEta(0), scPhi(0),
-      calibPt(0), calibE(0), eRes(-1),
+      calibPt(0), calibE(0), eRes(-1), ecalEnergyErrPostCorr(0),
+      energyScaleStatUp(0), energyScaleStatDown(0), 
+      energyScaleSystUp(0), energyScaleSystDown(0),
+      energyScaleGainUp(0), energyScaleGainDown(0),
+      energySigmaRhoUp(0), energySigmaRhoDown(0),
+      energySigmaPhiUp(0), energySigmaPhiDown(0),
       trkIso(-1), ecalIso(-1), hcalIso(-1),
       chHadIso(-1), gammaIso(-1), neuHadIso(-1),
 //      chHadIsoSelVtx, chHadIso03WstVtx;
-      mva(-999.), mvaV2(-999.), 
+      mvaSpring16(-999.), mvaFall17V1(-999.), mvaFall17V2(-999.),
+      mvaSpring16Cat(-999.), mvaFall17V1Cat(-999.), mvaFall17V2Cat(-999),
       hovere(0), sthovere(0), sieie(0), sipip(0), r9(0), r9_full5x5(0),
       fiducialBits(0),
       typeBits(0),
@@ -29,12 +35,21 @@ namespace baconhep
       float          pt, eta, phi;                         // kinematics
       float          scEt, scEta, scPhi;                   // SuperCluster kinematics
       float          calibPt, calibE, eRes;                // calibrated kinematics
+      float          ecalEnergyErrPostCorr;
+      float          energyScaleStatUp, energyScaleStatDown;   // uncertainties on kinematics with scale/smearing
+      float          energyScaleSystUp, energyScaleSystDown;
+      float          energyScaleGainUp, energyScaleGainDown;
+      float          energySigmaRhoUp, energySigmaRhoDown;
+      float          energySigmaPhiUp, energySigmaPhiDown;
       float          trkIso, ecalIso, hcalIso;             // detector isolation
       float          chHadIso, gammaIso, neuHadIso;        // PF isolation variables
-//      float          chHadIsoSelVtx,chHadIso03WstVtx;      // Isolation from the PV vs worst vertex Iso
-      float          mva;                                  // Photon MVA ID
-      float          mvaV2;                                // Photon MVA V2 ID
-      float          mvaCat, mvaV2Cat;                     // Photon MVA categories
+//      float          chHadIsoSelVtx,chHadIso03WstVtx;    // Isolation from the PV vs worst vertex Iso
+      float          mvaSpring16;                          // Photon MVA ID
+      float          mvaFall17V1;                          // Photon MVA ID
+      float          mvaFall17V2;                          // Photon MVA V2 ID
+      float          mvaSpring16Cat;                       // Photon MVA categories
+      float          mvaFall17V1Cat;
+      float          mvaFall17V2Cat;                       
       float          hovere;                               // H/E
       float          sthovere;                             // Single tower H/E (https://twiki.cern.ch/twiki/bin/viewauth/CMS/HoverE2012)
       float          sieie, sipip, r9, r9_full5x5;         // shower shape
@@ -46,7 +61,7 @@ namespace baconhep
       bool           isConv;                               
       TriggerObjects hltMatchBits;                         // HLT matches
           
-    ClassDef(TPhoton,4)
+    ClassDef(TPhoton,5)
   };
 
   enum EPhotonType


### PR DESCRIPTION
Updating electron and photon classes to be consistent with most recent BaconProd development (PR 27). Also adding 2017 double muon trigger, j/psi, upsilon, mumug triggers to HLT file.