### PR TITLE
avoid trigger memory bug

### DIFF
--- a/DataFormats/interface/BaconAnaDefs.hh
+++ b/DataFormats/interface/BaconAnaDefs.hh
@@ -40,9 +40,9 @@ enum EMETFilterFailBit
   kEcalBadCalibFilter                   = 262144
 };
 
-const unsigned int kNTrigBit = 256;
+const unsigned int kNTrigBit = 512;
 typedef std::bitset<kNTrigBit> TriggerBits;
-const unsigned int kNTrigObjectBit = 256;
+const unsigned int kNTrigObjectBit = 512;
 typedef std::bitset<kNTrigObjectBit> TriggerObjects;
 
 #endif


### PR DESCRIPTION
See BaconProd PR for more description of a memory bug involving TriggerBits. This change updates the value of kNTrigBit to a larger value, which should be safely larger than the total number of trigger paths in the HLT file. 